### PR TITLE
Add Support for Base URL Customization

### DIFF
--- a/appdev.go
+++ b/appdev.go
@@ -39,7 +39,7 @@ func (client *Client) AppDetails() (AppDescriptor, error) {
 	}
 
 	// Generate Request Object
-	requestHTTP, err := http.NewRequest("GET", urlAppDetails, nil)
+	requestHTTP, err := http.NewRequest("GET", client.serviceURL("/appdetails"), nil)
 	if err != nil {
 		return AppDescriptor{}, fmt.Errorf("request generation failed: %w", err)
 	}
@@ -128,7 +128,7 @@ type responseDevDetails struct {
 // DevDetails returns the details of developer user the client is configured for as a DevDescriptor object
 func (client *Client) DevDetails() (DevDescriptor, error) {
 	// Generate Request Object
-	requestHTTP, err := http.NewRequest("GET", urlDevDetails, nil)
+	requestHTTP, err := http.NewRequest("GET", client.serviceURL("/devstat"), nil)
 	if err != nil {
 		return DevDescriptor{}, fmt.Errorf("request generation failed: %w", err)
 	}

--- a/fileio.go
+++ b/fileio.go
@@ -24,7 +24,7 @@ func (client *Client) ReadFile(path string, version int) ([]byte, error) {
 	}
 
 	// Generate Request Object
-	requestHTTP, err := http.NewRequest("POST", urlReadFile, bytes.NewReader(requestData))
+	requestHTTP, err := http.NewRequest("POST", client.serviceURL("/readfile"), bytes.NewReader(requestData))
 	if err != nil {
 		return nil, fmt.Errorf("request generation failed: %w", err)
 	}
@@ -98,7 +98,7 @@ func (client *Client) WriteFile(data []byte, name string, opts ...WriteOption) (
 	}
 
 	// Generate Request Object
-	requestHTTP, err := http.NewRequest("POST", urlWriteFile, bytes.NewReader(requestData))
+	requestHTTP, err := http.NewRequest("POST", client.serviceURL("/writetexttofile"), bytes.NewReader(requestData))
 	if err != nil {
 		return FileDescriptor{}, fmt.Errorf("request generation failed: %w", err)
 	}
@@ -268,7 +268,7 @@ func (client *Client) RemoveFile(path string, version int, opts ...RemoveOption)
 	}
 
 	// Generate Request Object
-	requestHTTP, err := http.NewRequest("POST", urlRemoveFile, bytes.NewReader(requestData))
+	requestHTTP, err := http.NewRequest("POST", client.serviceURL("/remove"), bytes.NewReader(requestData))
 	if err != nil {
 		return fmt.Errorf("request generation failed: %w", err)
 	}
@@ -327,7 +327,7 @@ type responseMakeDir struct {
 // MakeDirectory creates a new directory at the given path which can than be used for storing files.
 func (client *Client) MakeDirectory(path string) error {
 	// Generate Request Object
-	requestHTTP, err := http.NewRequest("GET", urlMakeDir, nil)
+	requestHTTP, err := http.NewRequest("GET", client.serviceURL("/makedir"), nil)
 	if err != nil {
 		return fmt.Errorf("request generation failed: %w", err)
 	}

--- a/filestat.go
+++ b/filestat.go
@@ -82,7 +82,7 @@ func (client *Client) ListFiles(path string) ([]FileDescriptor, error) {
 	}
 
 	// Generate Request Object
-	requestHTTP, err := http.NewRequest("POST", urlListFiles, bytes.NewReader(requestData))
+	requestHTTP, err := http.NewRequest("POST", client.serviceURL("/listfiles"), bytes.NewReader(requestData))
 	if err != nil {
 		return nil, fmt.Errorf("request generation failed: %w", err)
 	}
@@ -134,7 +134,7 @@ func (client *Client) FileStatus(path string) (FileDescriptor, error) {
 	}
 
 	// Generate Request Object
-	requestHTTP, err := http.NewRequest("POST", urlFileStatus, bytes.NewReader(requestData))
+	requestHTTP, err := http.NewRequest("POST", client.serviceURL("/filestatus"), bytes.NewReader(requestData))
 	if err != nil {
 		return FileDescriptor{}, fmt.Errorf("request generation failed: %w", err)
 	}
@@ -185,7 +185,7 @@ func (client *Client) FileVersions(path string) ([]FileVersionDescriptor, error)
 	}
 
 	// Generate Request Object
-	requestHTTP, err := http.NewRequest("POST", urlFileVersions, bytes.NewReader(requestData))
+	requestHTTP, err := http.NewRequest("POST", client.serviceURL("/versions"), bytes.NewReader(requestData))
 	if err != nil {
 		return nil, fmt.Errorf("request generation failed: %w", err)
 	}


### PR DESCRIPTION
- Added a new ClientOption generator function BaseURL
- Added a url field on Client to store the BaseURL for the Client
- Removed the url* constants for all the service endpoints and replaced it with serviceURL method on Client that can generate the service endpoint with the client's base URL.
- Refactored all Client API methods to use the serviceURL generator